### PR TITLE
feat: output combined cert+key; add variable for extended key usage; fix missing variable reference

### DIFF
--- a/roles/clientcert/README.md
+++ b/roles/clientcert/README.md
@@ -10,6 +10,7 @@ Create private and public keys for a client.
 `clientcert_state_or_province` : State or Provice for certificate.
 `clientcert_org` : Organization for certificate.
 `clientcert_state` : If `present` creates certificate, if `absent` removes certificate.
+`clientcert_eku` : List of extended key usage options.
 
 ## Example Playbook
 
@@ -28,4 +29,5 @@ Create a private key and public certificate for a server.
         clientcert_org: Example Inc.
         rootca_password: changeme
         clientcert_hostname: server.example.com
+        clientcert_eku: ['serverAuth', 'clientAuth']
 ```

--- a/roles/clientcert/defaults/main.yml
+++ b/roles/clientcert/defaults/main.yml
@@ -16,4 +16,6 @@ clientcert_org: ""
 
 # Client certificate state
 clientcert_state: present
-...
+
+# Client certificate extended key usage
+clientcert_eku: ['serverAuth', 'clientAuth']

--- a/roles/clientcert/tasks/main.yml
+++ b/roles/clientcert/tasks/main.yml
@@ -38,3 +38,8 @@
     mode: '0444'
     state: "{{ clientcert_state }}"
 
+- name: Concatenate certificate and key files
+  ansible.builtin.shell: |
+    cat /etc/pki/CA/certs/{{ clientcert_hostname }}.cert.pem \
+        /etc/pki/CA/private/{{ clientcert_hostname }}.key.pem \
+        > /etc/pki/CA/certs/{{ clientcert_hostname }}-combined.cert.pem

--- a/roles/clientcert/tasks/main.yml
+++ b/roles/clientcert/tasks/main.yml
@@ -20,8 +20,7 @@
       - keyEncipherment
       - keyAgreement
     key_usage_critical: true
-    extended_key_usage:
-      - serverAuth
+    extended_key_usage: "{{ clientcert_eku }}"
     extended_key_usage_critical: true
     digest: sha256
     subject_alt_name:
@@ -38,4 +37,4 @@
     ownca_not_after: +3650d
     mode: '0444'
     state: "{{ clientcert_state }}"
-...
+

--- a/roles/rootca/tasks/main.yml
+++ b/roles/rootca/tasks/main.yml
@@ -71,7 +71,7 @@
   community.crypto.openssl_csr:
     path: /etc/pki/CA/csr/ca.cert.csr
     privatekey_path: /etc/pki/CA/private/ca.key.pem
-    privatekey_passphrase: changeme
+    privatekey_passphrase: "{{ rootca_password }}"
     common_name: Certificate Authority
     use_common_name_for_san: false
     basic_constraints:
@@ -95,4 +95,3 @@
     provider: selfsigned
     mode: '0444'
     state: "{{ rootca_state }}"
-...


### PR DESCRIPTION
This pull request fixes a missing reference to the rootca_password in the when issuing a new rootca. Furthermore it allows you to specify the extended key usage for new client ceritifcates and outputs a combined file with cert+key for further purposes.